### PR TITLE
Update gettingstarted.clj

### DIFF
--- a/src/sqlkorma/examples/gettingstarted.clj
+++ b/src/sqlkorma/examples/gettingstarted.clj
@@ -8,4 +8,4 @@
 ;; Example for h2:
 [com.h2database/h2 "1.3.170"]
 ;; Example for sqlite:
-[org.xerial/sqlite-jdbc "3.7.2"]
+[org.xerial/sqlite-jdbc "3.7.15-M1"]


### PR DESCRIPTION
The new sqlite3 version seems to handle inserts better.

Previously (insert table (values manyrows)) failed meaning you had to do (doseq [row manyrows](insert table %28values row%29)).
