### PR TITLE
updated documentation to reflect newly implemented support for composite keys

### DIFF
--- a/src/sqlkorma/examples/entities.clj
+++ b/src/sqlkorma/examples/entities.clj
@@ -57,7 +57,7 @@
 (defentity address
   (pk :my_pk) ;; sets the primary key to "my_pk"
   (belongs-to users)
-  (belongs-to state {:fk :id_state}))
+  (belongs-to state (fk :id_state)))
       ;; you can optionally specify the foreign key
       ;; assumes state.id = address.id_state
 
@@ -66,11 +66,17 @@
   (has-many address))
 
 (defentity account
-  (has-one users))
+  (pk :id1 :id2)
+      ;; you can also set the entity primary key to a
+      ;; composite key ("id1", "id2")
+  (has-one users (fk :account_id1 :account_id2)))
+      ;; and set the composite foreign keys to join
+      ;; on account.id1 = users.account_id1
+      ;; and account.id2 = users.account_id2
 
 (defentity posts
   (many-to-many users :users_posts
-    {:lfk :posts_id :rfk :users_id})
+    (lfk :posts_id) (rfk :users_id)))
       ;; you can optionally specify the foreign keys
       ;; left foreign key is for the main entity and
       ;; right foreign key is for the joined entity

--- a/src/sqlkorma/examples/realworld.clj
+++ b/src/sqlkorma/examples/realworld.clj
@@ -4,7 +4,7 @@
 (defentity users
   (table :somecrazy_table_name :users)
   (pk :userID)
-  (has-many address {:fk :userID}))
+  (has-many address (fk :userID)))
 
 (select users
   (with address)

--- a/src/sqlkorma/models/examples.clj
+++ b/src/sqlkorma/models/examples.clj
@@ -15,7 +15,8 @@
    "and" "or" "=" ">=" ">" "<" "<=" "not" "not-in" "not=" "in" "count" "sum"
    "avg" "exec" "sql-only" "dry-run" "exec-raw" "raw" "as-sql" "union"
    "union\\*" "union-all" "union-all\\*" "intersect" "intersect\\*" "queries"
-   "having" "having\\*" "where\\*" "modifier" "many-to-many" "msaccess" "h2"])
+   "having" "having\\*" "where\\*" "modifier" "many-to-many" "msaccess" "h2"
+   "fk" "lfk" "rfk"])
 
 (def clojure-vars ["def" "->" "defn" "use" "require" "ns" "if-not" "when-not"
                    "println" "declare"])


### PR DESCRIPTION
augmented one of the examples to show composite keys support, also updated references to fk, lfk and rfk for which only a keyword is no longer valid and a sequence must be provided (preferably via fk, lfk, rfk)
