### PR TITLE
Clarify that entity-fields are always selected

### DIFF
--- a/src/sqlkorma/examples/selects.clj
+++ b/src/sqlkorma/examples/selects.clj
@@ -6,6 +6,8 @@
                ;; defined in the entity
   (fields [:first :firstname] :last :address.zip)
       ;; you can alias a field using a vector of [field alias]
+      ;; these fields will be selected in addition to those defined
+      ;; using (entity-fields) in (defentity)
   (modifier "DISTINCT") ;; you can add a modifier
   (aggregate (count :*) :cnt :status)
       ;; You specify alias and optionally a field to group by


### PR DESCRIPTION
See korma/Korma#340 - I found this behavior counterintuitive the first time I used this library, so I'd like to make the documentation more explicit.